### PR TITLE
Add support of TableArgs

### DIFF
--- a/src/jasmine-cucumber.js
+++ b/src/jasmine-cucumber.js
@@ -17,7 +17,7 @@
 			  var args = Array.prototype.splice.call(arguments, 2);
               this.steps.push({
                 description : arguments[1],
-                fullDescription : arguments[0] + '  ' + arguments[1] + ' ' + JSON.stringify(args),
+                fullDescription : arguments[0] + '  ' + arguments[1] + ' ' + (args && args.length > 0 ? JSON.stringify(args, null, 2) : ''),
                 arguments : args
               });
             };


### PR DESCRIPTION
When test failure, log in karma console does not display tableargs for
step.
For exemple :
Given I init config to
| key   | value  |
| propA | valueA |
| propB | valueB |

is transform to :
.given ('I init config to',
[{"key":"propA","value":"valueA"},{"key":"propB","value":"valueB"}])

to match the step :
.given('I init config to', function(table /\* json */)

When the test fail, it display :
...
I init config to
[[{"key":"propA","value":"valueA"},{"key":"propB","v":"valueB"}]]
... FAILED

instead of
...
I init config to
... FAILED
