### PR TITLE
Nice display of Table arguments steps

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -15,6 +15,7 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
+      'src/karma-jasmine-step-parser.js',
       'src/jasmine-cucumber.js',
       'src/jasmine-feature-runner.js',
       'src/karma-jasmine-runner.js',

--- a/src/jasmine-cucumber.js
+++ b/src/jasmine-cucumber.js
@@ -6,7 +6,6 @@
         }
     };
 
-
     function Feature(featureDescription){
         function Scenario(scenarioDescription, options){
             var self = this;
@@ -17,7 +16,9 @@
 			  var args = Array.prototype.splice.call(arguments, 2);
               this.steps.push({
                 description : arguments[1],
-                fullDescription : arguments[0] + '  ' + arguments[1] + ' ' + (args && args.length > 0 ? JSON.stringify(args, null, 2) : ''),
+				fullDescription : arguments[0] + '  ' + arguments[1] + ' ' + (args && args.length > 0 ? JSON.stringify(args, null, 2) : ''),
+				/* replace with : 
+					fullDescription : exports.featureStepStringify(arguments[0], arguments[1], args), */
                 arguments : args
               });
             };
@@ -112,6 +113,7 @@
         }
     }
 
+	
     exports.feature = feature;
     exports.featureSteps = function(featurePattern, callback){
         var featureSteps = new FeatureSteps(featurePattern, callback);

--- a/src/karma-jasmine-step-parser.js
+++ b/src/karma-jasmine-step-parser.js
@@ -1,0 +1,69 @@
+(function(exports){
+	
+	function StepParser(keyWord, description, parameters){
+		this.keyWord = keyWord;
+		this.description = description;
+		this.parameters = parameters ? parameters[0] : null;
+		
+		if (this.parameters && !Array.isArray(this.parameters)) { 
+			this.parameters = [this.parameters];
+		}
+	}
+	
+	StepParser.NewLine = '\n\t | ';
+	StepParser.Separator = ' | ';
+	
+	StepParser.prototype.getParametersNames = function(){
+		return Object.keys(this.parameters[0]);
+	}
+	
+	StepParser.prototype.getParameterMaxLength = function(paramKey){
+		return this.parameters.map(function(param){
+			return param[paramKey];
+		}).reduce(function (longest, entry) {
+			return entry.length > longest ? entry.length : longest;
+		}, paramKey.length);
+	}
+	
+	StepParser.prototype.formatParameter = function(key, value){
+		var paramKeys = this.getParametersNames();
+		var length = this.getParameterMaxLength(key, paramKeys);
+		var padding = new Array(length).join(' ');
+		return (padding + value).slice(-1 * length) + StepParser.Separator;
+	}
+	
+	StepParser.prototype.stringify = function(){
+		var stepFullDescription = this.keyWord + " " + this.description;
+		
+		if (this.parameters){
+			stepFullDescription += this.stringifyParams();
+		}
+		return stepFullDescription;
+	}
+
+	StepParser.prototype.stringifyParams = function(){
+		var stepParams = StepParser.NewLine;
+		
+		var paramKeys = this.getParametersNames();
+		
+		var self = this;
+		paramKeys.forEach(function(key){
+			stepParams += self.formatParameter(key, key);
+		});
+		
+		var self = this;
+		this.parameters.forEach(function(param){
+			stepParams += StepParser.NewLine;
+			paramKeys.forEach(function(key){
+				stepParams += self.formatParameter(key, param[key]);
+			});
+		});
+		
+		return stepParams;
+	}
+	
+    exports.featureStepStringify = function(keyWord, description, parameters){
+        return new StepParser(keyWord, description, parameters).stringify();
+    };
+	
+}(typeof window !== 'undefined' ? window : module.exports));

--- a/test/karma-jasmine-step-parser-specs.js
+++ b/test/karma-jasmine-step-parser-specs.js
@@ -1,0 +1,38 @@
+describe('Step parser',function(){
+	it('Should stringify step with no parameters table', function() {
+		var result = featureStepStringify("Given", "a person", undefined);
+		expect(result).toBe('Given a person');
+	});
+	
+	/*
+	Given a person
+		|  name | age |
+		| Lance |   3 |
+	*/
+	it('Should stringify step with one parameter in the table', function() {
+		var result = featureStepStringify("Given", "a person", 
+			[{ name : 'Lance', age : 3 }]
+		);
+		
+		expect(result).toBe('Given a person\n'+
+		'\t |  name | age | \n'+
+		'\t | Lance |   3 | ');
+	});
+	
+	/*
+	Given a person
+		|  name | age |
+		| Lance |   3 |
+		|  Lana |   2 |
+	*/
+	it('Should stringify step with multiple parameters table', function() {
+		var result = featureStepStringify("Given", "a person", [
+			[{ name : 'Lance', age : 3 }, { name : 'Lana', age : 2 }]
+		]);
+		expect(result).toBe('Given a person\n'+
+		'\t |  name | age | \n'+
+		'\t | Lance |   3 | \n'+
+		'\t |  Lana |   2 | ');
+	})
+	
+});


### PR DESCRIPTION
I'd like to change the way table arguments are display in order to make
it looks more like gherkin's syntaxe.

To to that, i'd suggest to use the StepParser to stringfy the tableargs
in json and transform it to a :
|     ArgA |     ArgB |
| Value A | Value B |

It will be far more readable in the output.

Just need to change the fullDescription to
exports.featureStepStringify(arguments[0], arguments[1], args),

(And add the reference to the file in karma-jasmine-cucumber)
I'd like to change the way table arguments are display in order to make it looks more like gherkin's syntaxe.

To to that, i'd suggest to use the StepParser to stringfy the tableargs in json and transform it to a : 
|     ArgA |     ArgB |
| Value A | Value B |

It will be far more readable in the output.

Just need to change the fullDescription to exports.featureStepStringify(arguments[0], arguments[1], args),

(And add the reference to the file in karma-jasmine-cucumber).

Could you review ?